### PR TITLE
restore custom CSS injection

### DIFF
--- a/includes/rsvp_frontend.inc.php
+++ b/includes/rsvp_frontend.inc.php
@@ -41,7 +41,7 @@ function rsvp_frontend_handler( $text ) {
 	add_action( 'wp_footer', 'rsvp_front_scripts', 15 );
 
 	// Add custom style if plugin is loaded on page.
-	add_action( 'wp_footer', 'rsvp_add_css', 30 );
+	add_action( 'wp_footer', 'enqueue_rsvp_custom_css', 15 );
 
 	$rsvp_form_action = rsvp_getCurrentPageURL();
 

--- a/wp-rsvp.php
+++ b/wp-rsvp.php
@@ -616,13 +616,13 @@ function rsvp_hide_untill_loaded() {
 		echo '<style type="text/css">.rsvpArea, .rsvpParagraph, #rsvpPlugin {display:none;} </style>';
 }
 
-function rsvp_add_css() {
+function enqueue_rsvp_custom_css() {
 	$css = get_option( RSVP_OPTION_CSS_STYLING );
 
 	if ( ! empty( $css ) ) {
+		$output = wp_kses( $css, 'strip' );
 
-		echo '<!-- RSVP Free Styling -->
-		<style id="rsvp_plugin-custm-style" type="text/css">' . wp_kses_post( $css ) . '</style>';
+		wp_add_inline_style( 'rsvp_css', $output );
 	}
 }
 


### PR DESCRIPTION
This PR addresses [Custom CSS loader does not wrap styles with style tag](https://github.com/WPChill/rsvp/issues/77), a regression bug introduced by commit [sanitizations part 2; add package and grunt file](https://github.com/WPChill/rsvp/commit/aae1f1b00d6bb0be6f165f171b557b3708c607e9)

*Cause*
By default, WordPress kses post context does not accept the style tag. Consequently, the style tag wrapper is stripped, leaving baretext css styles at the location of the theme's wp_footer()

*Fix*
Inject inline CSS using WordPress-native [wp_add_inline_style](https://developer.wordpress.org/reference/functions/wp_add_inline_style/), and filter the CSS with a strip-all-html kses context.

*Risk*
A minor issue will be introduced as the injected style's ID tag will change from _rsvp_plugin-custm-style_ to _rsvp_css-inline-css_ as per WordPress' auto-naming scheme.